### PR TITLE
Fixed ambiguous operator when using base-4.11 onwards.

### DIFF
--- a/src/AutoBench/Internal/Regression.hs
+++ b/src/AutoBench/Internal/Regression.hs
@@ -1,5 +1,6 @@
 
-{-# OPTIONS_GHC -Wall #-}  
+{-# OPTIONS_GHC -Wall #-}
+{-# LANGUAGE CPP #-}
 
 {-|
 
@@ -81,6 +82,12 @@ import AutoBench.Internal.Types
   , LinearType(..)
   , numPredictors 
   )
+
+#ifdef MIN_VERSION_base
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
+#endif
 
 -- * 'LinearCandidate' generation
 


### PR DESCRIPTION
In `base-4.11` `Semigroup` was made a superclass of `Monoid` so since then `Semigroup`'s `(<>)` operator has been imported by default. This was clashing with `(<>)` imported from the `Numeric.LinearAlgebra` package.